### PR TITLE
imp: rename `CheckSubstituteAndUpdateState` to `MigrateClientStore`

### DIFF
--- a/light-clients/ics07-tendermint-cw/src/contract.rs
+++ b/light-clients/ics07-tendermint-cw/src/contract.rs
@@ -238,7 +238,7 @@ fn process_message(
 					Ok(to_binary(&ContractResult::success().heights(heights)))
 				})
 		},
-		SudoMsg::CheckSubstituteAndUpdateState(_msg) =>
+		SudoMsg::MigrateClientStore(_msg) =>
 			check_substitute_and_update_state::<HostFunctions>(ctx)
 				.map_err(|e| ContractError::Tendermint(e.to_string()))
 				.and_then(|(cs, cu)| {

--- a/light-clients/ics07-tendermint-cw/src/msg.rs
+++ b/light-clients/ics07-tendermint-cw/src/msg.rs
@@ -117,7 +117,7 @@ impl ContractResult {
 
 #[cw_serde]
 pub enum SudoMsg {
-	CheckSubstituteAndUpdateState(CheckSubstituteAndUpdateStateMsg),
+	MigrateClientStore(MigrateClientStoreMsg),
 	UpdateStateOnMisbehaviour(UpdateStateOnMisbehaviourMsgRaw),
 	UpdateState(UpdateStateMsgRaw),
 	VerifyMembership(VerifyMembershipMsgRaw),
@@ -250,7 +250,7 @@ impl TryFrom<UpdateStateMsgRaw> for UpdateStateMsg {
 }
 
 #[cw_serde]
-pub struct CheckSubstituteAndUpdateStateMsg {}
+pub struct MigrateClientStoreMsg {}
 
 #[cw_serde]
 pub struct VerifyMembershipMsgRaw {

--- a/light-clients/ics10-grandpa-cw/src/contract.rs
+++ b/light-clients/ics10-grandpa-cw/src/contract.rs
@@ -19,7 +19,7 @@ use crate::{
 	ics23::FakeInner,
 	log,
 	msg::{
-		CheckForMisbehaviourMsg, CheckSubstituteAndUpdateStateMsg,
+		CheckForMisbehaviourMsg, MigrateClientStoreMsg,
 		ContractResult, SudoMsg, ExportMetadataMsg, QueryMsg, QueryResponse,
 		StatusMsg, UpdateStateMsg, UpdateStateOnMisbehaviourMsg, VerifyClientMessage,
 		VerifyMembershipMsg, VerifyNonMembershipMsg, VerifyUpgradeAndUpdateStateMsg,
@@ -220,8 +220,8 @@ fn process_message(
 					store_client_and_consensus_states(ctx, client_id.clone(), cs, cu)
 				})
 		},
-		SudoMsg::CheckSubstituteAndUpdateState(msg) => {
-			let _msg = CheckSubstituteAndUpdateStateMsg::try_from(msg)?;
+		SudoMsg::MigrateClientStore(msg) => {
+			let _msg = MigrateClientStoreMsg::try_from(msg)?;
 			// manually load both states from the combined storage using the appropriate prefixes
 			let mut old_client_state = ctx
 				.client_state_prefixed(SUBJECT_PREFIX)

--- a/light-clients/ics10-grandpa-cw/src/msg.rs
+++ b/light-clients/ics10-grandpa-cw/src/msg.rs
@@ -136,7 +136,7 @@ pub struct ClientCreateRequest {
 
 #[cw_serde]
 pub enum SudoMsg {
-	CheckSubstituteAndUpdateState(CheckSubstituteAndUpdateStateMsgRaw),
+	MigrateClientStore(MigrateClientStoreMsgRaw),
 	UpdateStateOnMisbehaviour(UpdateStateOnMisbehaviourMsgRaw),
 	UpdateState(UpdateStateMsgRaw),
 	VerifyMembership(VerifyMembershipMsgRaw),
@@ -269,15 +269,15 @@ impl TryFrom<UpdateStateMsgRaw> for UpdateStateMsg {
 }
 
 #[cw_serde]
-pub struct CheckSubstituteAndUpdateStateMsgRaw {}
+pub struct MigrateClientStoreMsgRaw {}
 
-pub struct CheckSubstituteAndUpdateStateMsg {}
+pub struct MigrateClientStoreMsg {}
 
-impl TryFrom<CheckSubstituteAndUpdateStateMsgRaw> for CheckSubstituteAndUpdateStateMsg {
+impl TryFrom<MigrateClientStoreMsgRaw> for MigrateClientStoreMsg {
 	type Error = ContractError;
 
 	fn try_from(
-		CheckSubstituteAndUpdateStateMsgRaw {}: CheckSubstituteAndUpdateStateMsgRaw,
+		MigrateClientStoreMsgRaw {}: MigrateClientStoreMsgRaw,
 	) -> Result<Self, Self::Error> {
 		Ok(Self {})
 	}


### PR DESCRIPTION
ref: https://github.com/cosmos/ibc-go/issues/4862